### PR TITLE
Refactor CSV parser to make use of common DAO code.

### DIFF
--- a/app/actors/KafkaActorSingleton.java
+++ b/app/actors/KafkaActorSingleton.java
@@ -22,7 +22,7 @@ public class KafkaActorSingleton {
         ActorSystem system = ActorSystem.create("KafkaActorSystem");
         final EntityManagerFactory emf = Persistence.createEntityManagerFactory("data_discovery");
         final EntityManager em = emf.createEntityManager();
-        final DataPointMapper dataPointMapper = new DataPointMapper(new InputCSVParser(), em);
+        final DataPointMapper dataPointMapper = new DataPointMapper(new InputCSVParser(em), em);
 
         final ActorRef listener = system.actorOf(Props.create(KafkaActor.class, dataPointMapper), "listener");
 

--- a/app/services/DataPointMapper.java
+++ b/app/services/DataPointMapper.java
@@ -86,7 +86,7 @@ public class DataPointMapper {
         logger.debug("rowDataArray: {}", (Object) rowDataArray);
 
         DimensionalDataSet dataSet = findOrCreateDataset(dataPointRecord.getDatasetID(), dataPointRecord.getFilename());
-        inputCSVParser.parseRowdataDirectToTables(entityManager, rowDataArray, dataSet);
+        inputCSVParser.parseRowdataDirectToTables(rowDataArray, dataSet);
     }
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies ++= Seq(
   javaWs,
   javaJpa,
   "org.eclipse.persistence" % "eclipselink" % "2.6.2",
-  "com.github.ONSdigital" % "dp-dd-backend-model" % "develop-SNAPSHOT",
+  "com.github.ONSdigital" % "dp-dd-backend-model" % "feature~dao-SNAPSHOT",
 //  "uk.co.onsdigital.discovery" % "dd-model" % "1.0.0-SNAPSHOT",
   "org.postgresql" % "postgresql" % "9.4.1208.jre7",
   "org.apache.kafka" % "kafka-clients" % "0.10.1.0",

--- a/conf/META-INF/persistence.xml
+++ b/conf/META-INF/persistence.xml
@@ -30,7 +30,14 @@
             <property name="javax.persistence.jdbc.driver" value="org.postgresql.Driver" />
             <property name="javax.persistence.jdbc.user" value="data_discovery" />
             <property name="javax.persistence.jdbc.password" value="password" />
-            <property name="eclipselink.logging.level" value="ALL" />
+            <property name="eclipselink.logging.level" value="INFO" />
+            <!-- Enable batch writing -->
+            <property name="eclipselink.jdbc.batch-writing" value="JDBC"/>
+            <!-- Batch size -->
+            <property name="eclipselink.jdbc.batch-writing.size" value="2000"/>
+            <property name="reWriteBatchedInserts" value="true"/>
+            <property name="prepareThreshold" value="1"/>
+            <property name="eclipselink.persistence-context.flush-mode" value="commit"/>
 
             <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
             <property name="javax.persistence.schema-generation.scripts.action" value="drop-and-create"/>

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -25,7 +25,7 @@
   </appender>
 
   <logger name="play" level="INFO" />
-  <logger name="application" level="DEBUG" />
+  <logger name="application" level="INFO" />
 
   <!-- Off these ones as they are annoying, and anyway we manage configuration ourselves -->
   <logger name="com.avaje.ebean.config.PropertyMapLoader" level="OFF" />

--- a/test/main/LoadSingleDataPointToDatabaseTest.java
+++ b/test/main/LoadSingleDataPointToDatabaseTest.java
@@ -57,8 +57,8 @@ public class LoadSingleDataPointToDatabaseTest extends TestNGSuite {
             DataResource dataResource = em.find(DataResource.class, datasetId);
             DimensionalDataSet dimensionalDataSet = dataResource.getDimensionalDataSets().get(0);
 
-            new InputCSVParser().parseRowdataDirectToTables(em, rowDataArray, dimensionalDataSet);
-
+            new InputCSVParser(em).parseRowdataDirectToTables(rowDataArray, dimensionalDataSet);
+            em.flush();
 
             DimensionalDataPoint result = em.createQuery("SELECT ddp FROM DimensionalDataPoint ddp WHERE ddp.value = 676767", DimensionalDataPoint.class).getSingleResult();
 

--- a/test/main/PostgresTest.java
+++ b/test/main/PostgresTest.java
@@ -45,7 +45,7 @@ public class PostgresTest {
                 dimensionalDataSet.setDimensionalDataSetId(UUID.fromString(id));
                 em.persist(dimensionalDataSet);
             }
-            new InputCSVParser().run(em, dimensionalDataSet, inputFile);
+            new InputCSVParser(em).run(dimensionalDataSet, inputFile);
 
             em.flush();
             em.clear();

--- a/test/resources/META-INF/persistence.xml
+++ b/test/resources/META-INF/persistence.xml
@@ -31,6 +31,14 @@
             <property name="javax.persistence.jdbc.user" value="data_discovery" />
             <property name="javax.persistence.jdbc.password" value="password" />
             <property name="eclipselink.logging.level" value="ALL" />
+            <!-- Enable batch writing -->
+            <property name="eclipselink.jdbc.batch-writing" value="JDBC"/>
+            <!-- Batch size -->
+            <property name="eclipselink.jdbc.batch-writing.size" value="2000"/>
+            <property name="reWriteBatchedInserts" value="true"/>
+            <property name="prepareThreshold" value="1"/>
+            <property name="eclipselink.persistence-context.flush-mode" value="commit"/>
+
 
             <property name="javax.persistence.schema-generation.database.action" value="drop-and-create"/>
             <property name="javax.persistence.schema-generation.scripts.action" value="drop-and-create"/>

--- a/test/services/DataPointMapperTest.java
+++ b/test/services/DataPointMapperTest.java
@@ -132,7 +132,7 @@ public class DataPointMapperTest {
 
         dataPointMapper.mapDataPoint(record);
 
-        verify(mockCsvParser).parseRowdataDirectToTables(mockEntityManager, new String[] { "a", "b", "c"}, dataSet);
+        verify(mockCsvParser).parseRowdataDirectToTables(new String[] { "a", "b", "c"}, dataSet);
     }
 
     @Test(expectedExceptions = IOException.class)


### PR DESCRIPTION
Pulled out JPA-specific code into a DAO that lives with the model classes. This ensures that the code that uses named queries is defined in the same project that actually defines them, for maintainability.

I've also tweaked the persistence.xml parameters to provide hints to enable batch inserts in postgresql. This results in approximately 2x speedup in simple tests, and should result in much more efficient use of the database in larger workloads. 