### PR TITLE
Added outstanding unit tests to 'unit-test' group

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
 //  "uk.co.onsdigital.discovery" % "dd-model" % "1.0.0-SNAPSHOT",
   "org.postgresql" % "postgresql" % "9.4.1208.jre7",
   "org.apache.kafka" % "kafka-clients" % "0.10.1.0",
-  "org.testng" % "testng" % "6.9.13.6" % Test,
+  "org.testng" % "testng" % "6.10" % Test,
   "org.mockito" % "mockito-all" % "1.9.5" % Test,
   "org.assertj" % "assertj-core" % "3.6.1" % Test,
   "de.johoop" % "sbt-testng-interface_2.10" % "3.0.0",

--- a/test/resources/testng.xml
+++ b/test/resources/testng.xml
@@ -12,6 +12,8 @@
 
         <classes>
             <class name="main.LoadCsvToDatabaseTest" />
+            <class name="services.DataPointMapperTest" />
+            <class name="utils.KafkaUtilsTest" />
         </classes>
 
     </test>

--- a/test/services/DataPointMapperTest.java
+++ b/test/services/DataPointMapperTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.*;
 
+@Test(groups="unit-test")
 public class DataPointMapperTest {
 
     @Mock

--- a/test/utils/KafkaUtilsTest.java
+++ b/test/utils/KafkaUtilsTest.java
@@ -12,6 +12,7 @@ import java.util.List;
 import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.assertThat;
 
+@Test(groups="unit-test")
 public class KafkaUtilsTest {
 
     @Test


### PR DESCRIPTION


### What

1. Added outstanding unit tests from other packages to unit-test group

2. Upgraded TestNG to 6.10 due to known ConcurrentModificationException bug in 6.9.13.6 (https://github.com/cbeust/testng/issues/1168)

### How to review

1. sbt "test-only scala.UnitTestRunner" should now run services.DataPointMapperTest and utils.KafkaUtilsTest.

2. Verify that the tail of the log doesn't show:

[TestNG] Reporter org.testng.reporters.JUnitReportReporter@4ca9c0c4 failed
java.util.ConcurrentModificationException
        at java.util.ArrayList$Itr.checkForComodification(ArrayList.java:901)



### Who can review

Anyone but Chris
