### PR TITLE
Adding command aliases for running unit tests and integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@ Navigate to http://localhost:9000/ to initialise the application.
 ----
 
 ```bash
-sbt "test-only scala.UnitTestRunner"
+sbt "test-only scala.UnitTestRunner"  (or it's alias - 'sbt test') 
 ```
 or
 ```bash
-sbt "test-only scala.IntTestRunner"
+sbt "test-only scala.IntTestRunner" (or it's alias 'sbt int-test')
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -27,6 +27,9 @@ libraryDependencies ++= Seq(
   "org.scalatestplus" %% "play" % "1.4.0-M4"
 )
 
+addCommandAlias("test", "testOnly scala.UnitTestRunner")
+addCommandAlias("int-test", "testOnly scala.IntTestRunner")
+
 EclipseKeys.projectFlavor := EclipseProjectFlavor.Java           // Java project. Don't expect Scala IDE
 EclipseKeys.createSrc := EclipseCreateSrc.ValueSet(EclipseCreateSrc.ManagedClasses, EclipseCreateSrc.ManagedResources)  // Use .class files instead of generated .scala files for views and routes
 EclipseKeys.preTasks := Seq(compile in Compile)


### PR DESCRIPTION
### What

Added 2 command aliases to the sbt.build file
Updated the README

### How to review

This means we can once again run the standard 'sbt clean compile test' command and it will not attempt to run the integration tests which are dependent on a running db and Kafka.

The integration tests can be run with the command 'sbt int-test' if so desired.

### Who can review

Anyone - check it out and type the commands above.
